### PR TITLE
Fix share button bug: Add missing fixedBlob parameter in displayPostRecordButtons call

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -199,7 +199,7 @@ if (CONFIG.API_TOKEN === "__API_TOKEN__") {
       const url = URL.createObjectURL(fixedBlob)
       //hide loading icon once video is done processing
       loadingIcon.style.display = "none"
-      displayPostRecordButtons(url)
+      displayPostRecordButtons(url, fixedBlob)
     }
     //Start recording
     mediaRecorder.start()


### PR DESCRIPTION
PR Description
This Pull Request fixes an issue where the fixedBlob parameter was not passed in the displayPostRecordButtons function call, causing the share button to not work as expected.

Changes Made
Updated the call to displayPostRecordButtons to include the fixedBlob parameter:
Original: displayPostRecordButtons(url)
Fixed: displayPostRecordButtons(url, fixedBlob)
